### PR TITLE
Revert "backward compatibility for caching done with old pandas indices"

### DIFF
--- a/result_caching/__init__.py
+++ b/result_caching/__init__.py
@@ -4,7 +4,6 @@ import inspect
 import itertools
 import logging
 import numpy as np
-import pandas as pd
 import os
 import pickle
 import xarray as xr
@@ -139,11 +138,8 @@ class _DiskStorage(_Storage):
 
     def load_file(self, path):
         with open(path, 'rb') as f:
-            try:
-                data = pickle.load(f)['data']
-            catch:
-                data = pd.read_pickle(f)['data']
-            return data
+            return pickle.load(f)['data']
+
 
 class _NetcdfStorage(_DiskStorage):
     def storage_path(self, function_identifier):


### PR DESCRIPTION
Reverts brain-score/result_caching#11

Builds are failing due to invalid catch syntax, e.g. https://travis-ci.com/github/brain-score/brain-score/jobs/495795368

```
E     File "/home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/result_caching/__init__.py", line 144
E       catch:
E           ^
E   SyntaxError: invalid syntax
```