### PR TITLE
backward compatibility for caching done with old pandas indices

### DIFF
--- a/result_caching/__init__.py
+++ b/result_caching/__init__.py
@@ -4,6 +4,7 @@ import inspect
 import itertools
 import logging
 import numpy as np
+import pandas as pd
 import os
 import pickle
 import xarray as xr
@@ -138,7 +139,7 @@ class _DiskStorage(_Storage):
 
     def load_file(self, path):
         with open(path, 'rb') as f:
-            return pickle.load(f)['data']
+            return pd.read_pickle(f)['data']
 
 
 class _NetcdfStorage(_DiskStorage):


### PR DESCRIPTION
Corrects #11 

I encountered FrozenIndices Error trying to load a pandas dataframe after updating my pandas version. This commit introduces backward compatibility, i.e. you are fine if you pickle.dump() using an old pandas' version and trying to load using a new pandas' version.
pandas-dev/pandas#34535

pickle.load() still called for all non Dataframe objects see https://github.com/pandas-dev/pandas/blob/f2c8480af2f25efdbd803218b9d87980f416563e/pandas/io/pickle.py#L203