### PR TITLE
specify md in setup so that pypi can build correctly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     version='0.1.0',
     description="Cache results for re-use",
     long_description=readme,
-    long_description_content_type='text/markdown',  # Specify Markdown format
+    long_description_content_type='text/markdown',
     author="Martin Schrimpf",
     author_email='martin.schrimpf@outlook.com',
     url='https://github.com/brain-score/result_caching',

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,10 @@ setup(
     version='0.1.0',
     description="Cache results for re-use",
     long_description=readme,
+    long_description_content_type='text/markdown',  # Specify Markdown format
     author="Martin Schrimpf",
     author_email='martin.schrimpf@outlook.com',
     url='https://github.com/brain-score/result_caching',
-
     packages=find_packages(exclude=['tests']),
     install_requires=requirements,
     license="MIT license",
@@ -38,5 +38,5 @@ setup(
         'Programming Language :: Python :: 3.11',
     ],
     test_suite='tests',
-    tests_require=test_requirements
+    tests_require=test_requirements,
 )


### PR DESCRIPTION
When building PyPi package, PyPI is trying to render README as reStructuredText (reST) by default (instead of md).